### PR TITLE
add get shutdown flag method.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<groupId>me.phoboslabs.illuminati</groupId>
 	<artifactId>illuminati-graceful-shutdown</artifactId>
-	<version>0.2.5.8</version>
+	<version>0.2.5.9</version>
 	<name>illuminati-graceful-shutdown</name>
 	<description>Graceful shutdown for Spring Boot 2.x project</description>
 

--- a/src/main/java/me/phoboslabs/illuminati/illuminatigracefulshutdown/shutdown/configuration/IlluminatiGSFilterConfiguration.java
+++ b/src/main/java/me/phoboslabs/illuminati/illuminatigracefulshutdown/shutdown/configuration/IlluminatiGSFilterConfiguration.java
@@ -74,4 +74,8 @@ public class IlluminatiGSFilterConfiguration extends OncePerRequestFilter {
             READY_TO_SHUTDOWN.set(true);
         }
     }
+
+    public static boolean isReadyToShutdown() {
+        return READY_TO_SHUTDOWN.get();
+    }
 }


### PR DESCRIPTION
Sometimes. We need a flag to confirm that the shutdown has begun.